### PR TITLE
CPU over-utilization patch

### DIFF
--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -37,7 +37,7 @@ Patch* patches[] = {
 	new Patch(Call, D2MULTI, 0x10781, (int)ChannelWhisper_Interception, 5),
 	new Patch(Jump, D2MULTI, 0x108A0, (int)ChannelChat_Interception, 6),
 	new Patch(Jump, D2MULTI, 0x107A0, (int)ChannelEmote_Interception, 6),
-	new Patch(NOP, D2CLIENT, 0x3CB83, 0, 2),
+	new Patch(NOP, D2CLIENT, 0x3CB7C, 0, 9),
 };
 
 Patch* BH::oogDraw = new Patch(Call, D2WIN, 0x18911, (int)OOGDraw_Interception, 5);

--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -37,6 +37,7 @@ Patch* patches[] = {
 	new Patch(Call, D2MULTI, 0x10781, (int)ChannelWhisper_Interception, 5),
 	new Patch(Jump, D2MULTI, 0x108A0, (int)ChannelChat_Interception, 6),
 	new Patch(Jump, D2MULTI, 0x107A0, (int)ChannelEmote_Interception, 6),
+	new Patch(NOP, D2CLIENT, 0x3CB83, 0, 2),
 };
 
 Patch* BH::oogDraw = new Patch(Call, D2WIN, 0x18911, (int)OOGDraw_Interception, 5);

--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -61,11 +61,13 @@ bool Patch::Install() {
 	//Set the code with all NOPs by default
 	memset(code, 0x90, length);
 
-	//Set the JMP or CALL opcode
-	code[0] = (type == Call) ? 0xE8 : 0xE9;
+	if (type != NOP) {
+		//Set the JMP or CALL opcode
+		code[0] = (type == Call) ? 0xE8 : 0xE9;
 
-	//Set the address to redirect to
-	*(DWORD*)&code[1] = function - (address + 5);
+		//Set the address to redirect to
+		*(DWORD*)&code[1] = function - (address + 5);
+	}
 
 	//Write the patch in
 	VirtualProtect((VOID*)address, length, PAGE_EXECUTE_READWRITE, &protect);

--- a/BH/Patch.h
+++ b/BH/Patch.h
@@ -6,7 +6,7 @@
 class Patch;
 
 enum Dll { D2CLIENT=0,D2COMMON,D2GFX,D2LANG,D2WIN,D2NET,D2GAME,D2LAUNCH,FOG,BNCLIENT, STORM, D2CMP, D2MULTI, D2MCPCLIENT};
-enum PatchType { Jump=0, Call };
+enum PatchType { Jump=0, Call, NOP };
 class Patch {
 	private:
 		static std::vector<Patch*> Patches;


### PR DESCRIPTION
D2 doesn't sleep properly each frame and uses way more cpu than it needs to. This fix is described at: http://d2mods.info/forum/viewtopic.php?f=8&t=62379&sid=31c24eb3e296cecbdcc8f371c8c69a07

The jump they NOP for singleplayer seems to be the right one for regular online play, I assume the multiplayer part is for hosting a tcp/ip game. I didn't patch that since I don't feel like testing it. 
I also NOP the two instructions before the jump since they have no purpose without it.

This cuts my D2 cpu usage in half without adversely affecting gameplay.
The same problem exists while in menus, but this doesn't fix that.. I'll try and figure that out too.
